### PR TITLE
feat: Better use of nvim api

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,403 @@
+# CreateDrawerOptions
+
+## nvim_tree_hack
+
+```lua
+boolean
+```
+
+Don't keep the same buffer across all tabs.
+
+## on_did_close
+
+```lua
+fun(event: { instance: DrawerInstance, winid: integer }):nil
+```
+
+Called after the drawer is closed. Only called if the drawer was actually
+open.
+Not called in the context of the drawer window.
+
+## on_did_create_buffer
+
+```lua
+fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }):nil
+```
+
+Called after a buffer is created. This is called very rarely.
+Called in the context of the drawer window.
+
+## on_did_open
+
+```lua
+fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }):nil
+```
+
+Called after .open() is done. Note this will be called even if the drawer
+is open.
+Called in the context of the drawer window.
+
+## on_did_open_buffer
+
+```lua
+fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }):nil
+```
+
+Called after a buffer is opened.
+Called in the context of the drawer window.
+
+## on_did_open_window
+
+```lua
+fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }):nil
+```
+
+Called after a window is created.
+Called in the context of the drawer window.
+
+## on_vim_enter
+
+```lua
+fun(event: { instance: DrawerInstance }):nil
+```
+
+Called when vim starts up. Helpful to have drawers appear in the order they
+were created in.
+Not called in the context of the drawer window.
+
+## on_will_close
+
+```lua
+fun(event: { instance: DrawerInstance }):nil
+```
+
+Called before the drawer is closed. Note this will is called even if the
+drawer is closed.
+Not called in the context of the drawer window.
+
+## on_will_create_buffer
+
+```lua
+fun(event: { instance: DrawerInstance }):nil
+```
+
+Called before a buffer is created. This is called very rarely.
+Not called in the context of the drawer window.
+
+## on_will_open_buffer
+
+```lua
+fun(event: { instance: DrawerInstance }):nil
+```
+
+Called before a buffer is opened.
+Not called in the context of the drawer window.
+
+## on_will_open_window
+
+```lua
+fun(event: { instance: DrawerInstance, bufnr: integer }):nil
+```
+
+Called before the window is created.
+Not called in the context of the drawer window.
+
+## position
+
+```lua
+'above'|'below'|'left'|'right'
+```
+
+Position of the drawer.
+
+## size
+
+```lua
+integer
+```
+
+Initial size of the drawer, in lines or columns.
+
+---
+
+# DrawerCloseOptions
+
+## save_size
+
+```lua
+boolean?
+```
+
+---
+
+# DrawerInstance
+
+## close
+
+```lua
+function DrawerInstance.close(opts?: DrawerCloseOptions)
+```
+
+Close the drawer. By default, the size of the drawer is saved.
+
+```lua
+example_drawer.close()
+
+--- Don't save the size of the drawer.
+example_drawer.close({ save_size = false })
+```
+
+## does_own_buffer
+
+```lua
+function DrawerInstance.does_own_buffer(bufnr: any)
+```
+
+Check if a buffer belongs to the drawer.
+
+## does_own_window
+
+```lua
+function DrawerInstance.does_own_window(winid: any)
+  -> boolean
+```
+
+Check if a window belongs to the drawer.
+
+## focus
+
+```lua
+function DrawerInstance.focus()
+```
+
+Focus the drawer.
+
+## focus_and_return
+
+```lua
+function DrawerInstance.focus_and_return(callback: fun())
+```
+
+Helper function to focus the drawer, run a callback, and return focus to
+the previous window.
+
+## focus_or_toggle
+
+```lua
+function DrawerInstance.focus_or_toggle()
+```
+
+Focus the drawer if it's open, otherwise toggle it, and give it focus
+when it is opened.
+
+## get_size
+
+```lua
+function DrawerInstance.get_size()
+  -> integer
+```
+
+Get the size of the drawer in lines or columns.
+
+## get_winid
+
+```lua
+function DrawerInstance.get_winid()
+  -> integer
+```
+
+Get the window id of the drawer. Returns `-1` if the drawer is not
+open.
+
+## go
+
+```lua
+function DrawerInstance.go(distance: integer)
+```
+
+Navigate to the next or previous buffer.
+
+```lua
+--- Go to the next buffer.
+example_drawer.go(1)
+
+--- Go to the previous buffer.
+example_drawer.go(-1)
+```
+
+## is_foucsed
+
+```lua
+function DrawerInstance.is_foucsed()
+  -> boolean
+```
+
+Check if the drawer is focused.
+
+## open
+
+```lua
+function DrawerInstance.open(opts?: DrawerOpenOptions)
+```
+
+Open the drawer.
+
+```lua
+example_drawer.open()
+
+--- Keep focus in the drawer.
+example_drawer.open({ focus = true })
+
+--- Open a new tab and focus it.
+example_drawer.open({ mode = 'new', focus = true })
+```
+
+## set_size
+
+```lua
+function DrawerInstance.set_size(size: integer)
+```
+
+Set the size of the drawer in lines or columns.
+
+## store_buffer_info
+
+```lua
+function DrawerInstance.store_buffer_info(winid: integer)
+```
+
+## toggle
+
+```lua
+function DrawerInstance.toggle(opts?: DrawerToggleOptions)
+```
+
+Toggle the drawer. Also lets you pass options to open the drawer.
+
+```lua
+example_drawer.toggle()
+
+--- Focus the drawer when opening it.
+example_drawer.toggle({ open = { focus = true } })
+```
+
+---
+
+# DrawerOpenOptions
+
+## focus
+
+```lua
+boolean?
+```
+
+## mode
+
+```lua
+('new'|'previous_or_new')?
+```
+
+---
+
+# DrawerState
+
+## buffers
+
+```lua
+integer[]
+```
+
+The number of all buffers that have been created.
+
+## count
+
+```lua
+integer
+```
+
+The number of buffers that have been created.
+
+## index
+
+```lua
+integer
+```
+
+The internal ID of the drawer.
+
+## is_open
+
+```lua
+boolean
+```
+
+Whether the drawer assumes it's open or not.
+
+## previous_bufnr
+
+```lua
+integer
+```
+
+The number of the previous buffer that was opened.
+
+## size
+
+```lua
+integer
+```
+
+The last known size of the drawer.
+
+## windows_and_buffers
+
+```lua
+table<integer, integer>
+```
+
+The windows belonging to the drawer.
+
+- @field winids integer[]
+
+---
+
+# DrawerToggleOptions
+
+## open
+
+```lua
+DrawerOpenOptions?
+```
+
+---
+
+# LuaLS
+
+---
+
+# NvimDrawerModule
+
+## create_drawer
+
+```lua
+function NvimDrawerModule.create_drawer(opts: CreateDrawerOptions)
+  -> DrawerInstance
+```
+
+Create a new drawer.
+
+```lua
+local example_drawer = drawer.create_drawer({
+  size = 15,
+  position = 'bottom',
+
+  on_did_create_buffer = function()
+  end,
+})
+```
+
+## setup
+
+```lua
+function NvimDrawerModule.setup(_: any)
+```

--- a/README.md
+++ b/README.md
@@ -40,26 +40,31 @@ First, you need to create a drawer via `create_drawer`:
 ```lua
 local drawer = require('nvim-drawer')
 
-local example_drawer = drawer.create_drawer({
-  bufname_prefix = 'example_drawer_',
+drawer.create_drawer({
   size = 15,
   position = 'bottom',
 })
 ```
 
 When opened, this drawer will be at the bottom of the screen, 15 lines tall,
-editing a buffer named `example_drawer_1`.
+editing a scratch buffer.
 
 This doesn't do much, you get a nice scratch space, but to get the most out of
 it, you need to use the API and add some key mappings.
 
-Your drawer has methods like:
+Your drawer has methods like ...
 
 - `open()`: Open the drawer.
 - `close()`: Close the drawer.
 - `toggle()`: Toggle the drawer.
 - `focus()`: Focus the drawer.
 - `go()`: Go to a different tab.
+
+... and callbacks like:
+
+- `on_did_create_buffer`: Called after a buffer is created.
+- `on_did_open_window`: Called after a drawer is opened.
+- `on_did_close`: Called after a drawer is closed.
 
 ## Examples
 
@@ -68,45 +73,51 @@ Your drawer has methods like:
 ```lua
 local drawer = require('nvim-drawer')
 
-local terminal_drawer = drawer.create_drawer({
+drawer.create_drawer({
   bufname_prefix = 'quick_terminal_',
   size = 15,
-  position = 'bottom',
+  position = 'below',
 
-  on_will_create_buffer = function()
+  on_vim_enter = function(event)
+    -- Open the drawer on startup.
+    event.instance.open({
+      focus = false,
+    })
+
+    -- Example keymaps:
+    -- C-`: focus the drawer.
+    -- <leader>tn: open a new terminal.
+    -- <leader>tt: go to the next terminal.
+    -- <leader>tT: go to the previous terminal.
+    vim.keymap.set('n', '<C-`>', function()
+      event.instance.focus_or_toggle()
+    end)
+    vim.keymap.set('n', '<leader>tn', function()
+      event.instance.open({ mode = 'new' })
+    end)
+    vim.keymap.set('n', '<leader>tt', function()
+      event.instance.go(1)
+    end)
+    vim.keymap.set('n', '<leader>tT', function()
+      event.instance.go(-1)
+    end)
+  end,
+
+  -- When a new buffer is created, switch it to a terminal.
+  on_did_create_buffer = function()
     vim.fn.termopen(os.getenv('SHELL'))
-
-    vim.opt_local.number = false
-    vim.opt_local.signcolumn = 'no'
-    vim.opt_local.statuscolumn = ''
   end,
 
-  on_did_open_buffer = function()
+  -- Remove some UI elements.
+  on_did_open_window = function()
+    vim.opt.number = false
+    vim.opt.signcolumn = 'no'
+    vim.opt.statuscolumn = ''
+  end,
+
+  -- Scroll to the end when changing tabs.
+  on_did_open = function()
     vim.cmd('$')
-  end,
-})
-
-vim.keymap.set('n', '<C-`>', function()
-  terminal_drawer.focus_or_toggle()
-end)
-
-vim.keymap.set('n', '<leader>tn', function()
-  terminal_drawer.open({ mode = 'new' })
-end)
-
-vim.keymap.set('n', '<leader>tt', function()
-  terminal_drawer.go(1)
-end)
-
-vim.keymap.set('n', '<leader>tT', function()
-  terminal_drawer.go(-1)
-end)
-
-vim.api.nvim_create_autocmd('VimEnter', {
-  desc = 'Open Tree automatically',
-  once = true,
-  callback = function()
-    terminal_drawer.open()
   end,
 })
 ```
@@ -116,374 +127,49 @@ vim.api.nvim_create_autocmd('VimEnter', {
 ```lua
 local drawer = require('nvim-drawer')
 
-local tree_drawer = drawer.create_drawer({
-  bufname_prefix = 'tree_',
+drawer.create_drawer({
   size = 40,
   position = 'right',
+  nvim_tree_hack = true,
 
-  on_did_open_buffer = function()
+  on_vim_enter = function(event)
+    --- Open the drawer on startup.
+    event.instance.open({
+      focus = false,
+    })
+
+    --- Example mapping to toggle.
+    vim.keymap.set('n', '<leader>e', function()
+      event.instance.focus_or_toggle()
+    end)
+  end,
+
+  --- Ideally, we would just call this here and be done with it, but
+  --- mappings in nvim-tree don't seem to apply when re-using a buffer in
+  --- a new tab / window.
+  on_did_create_buffer = function()
     local nvim_tree_api = require('nvim-tree.api')
     nvim_tree_api.tree.open({ current_window = true })
-    nvim_tree_api.tree.reload()
+  end,
 
-    -- NvimTree seems to set this back to true.
-    vim.opt_local.winfixheight = false
+  --- This gets the tree to sync when changing tabs.
+  on_did_open = function()
+    local nvim_tree_api = require('nvim-tree.api')
+    nvim_tree_api.tree.reload()
 
     vim.opt_local.number = false
     vim.opt_local.signcolumn = 'no'
     vim.opt_local.statuscolumn = ''
   end,
 
+  --- Cleans up some things when closing the drawer.
   on_did_close = function()
     local nvim_tree_api = require('nvim-tree.api')
     nvim_tree_api.tree.close()
   end,
 })
-
--- This is the trick to getting NvimTree working in a drawer.
--- We let NvimTree completely overwrite the split, which ends up renaming it to
--- something like `NvimTree_{N}`.
--- Then, we overwrite how the drawer is found so that any NvimTree windows are
--- found instead of drawer windows.
-local original_is_buffer = tree_drawer.is_buffer
-function tree_drawer.is_buffer(bufname)
-  return string.find(bufname, 'NvimTree_') ~= nil or original_is_buffer(bufname)
-end
-
-vim.keymap.set('n', '<leader>e', function()
-  tree_drawer.focus_or_toggle()
-end)
 ```
 
 ## API
 
-### CreateDrawerOptions
-
-#### bufname_prefix
-
-```lua
-string
-```
-
-Prefix used when creating buffers.
-Buffers will be named `{bufname_prefix}1`, `{bufname_prefix}2`, etc.
-
-#### on_did_close
-
-```lua
-(fun():nil)?
-```
-
-Called after the drawer is closed. Only called if the drawer was actually
-open.
-
-#### on_did_open_buffer
-
-```lua
-(fun(bufname: string):nil)?
-```
-
-Called after a buffer is opened.
-
-#### on_did_open_split
-
-```lua
-fun(bufname: string):nil
-```
-
-Called after a split is created.
-
-#### on_will_close
-
-```lua
-fun():nil
-```
-
-Called before the drawer is closed. Note this will is called even if the
-drawer is closed.
-
-#### on_will_create_buffer
-
-```lua
-(fun(bufname: string):nil)?
-```
-
-Called before a buffer is created. This is called very rarely.
-
-#### on_will_open_split
-
-```lua
-fun(bufname: string):nil
-```
-
-Called before the splt is created.
-
-#### position
-
-```lua
-'bottom'|'left'|'right'|'top'
-```
-
-Position of the drawer.
-
-#### size
-
-```lua
-integer
-```
-
-Initial size of the drawer, in lines or columns.
-
----
-
-### DrawerCloseOptions
-
-#### save_size
-
-```lua
-boolean?
-```
-
----
-
-### DrawerInstance
-
-#### close
-
-```lua
-function DrawerInstance.close(opts?: DrawerCloseOptions)
-```
-
-Close the drawer. By default, the size of the drawer is saved.
-
-```lua
-example_drawer.close()
-
---- Don't save the size of the drawer.
-example_drawer.close({ save_size = false })
-```
-
-#### focus
-
-```lua
-function DrawerInstance.focus()
-```
-
-Focus the drawer.
-
-#### focus_and_return
-
-```lua
-function DrawerInstance.focus_and_return(callback: fun())
-```
-
-Helper function to focus the drawer, run a callback, and return focus to
-the previous window.
-
-#### focus_or_toggle
-
-```lua
-function DrawerInstance.focus_or_toggle()
-```
-
-Focus the drawer if it's open, otherwise toggle it, and give it focus
-when it is opened.
-
-#### get_size
-
-```lua
-function DrawerInstance.get_size()
-  -> integer
-```
-
-Get the size of the drawer in lines or columns.
-
-#### get_winnr
-
-```lua
-function DrawerInstance.get_winnr()
-  -> integer
-```
-
-Get the window number of the drawer. Returns `-1` if the drawer is not
-open.
-
-#### go
-
-```lua
-function DrawerInstance.go(distance: integer)
-```
-
-Navigate to the next or previous buffer.
-
-```lua
---- Go to the next buffer.
-example_drawer.go(1)
-
---- Go to the previous buffer.
-example_drawer.go(-1)
-```
-
-#### is_buffer
-
-```lua
-function DrawerInstance.is_buffer(bufname: string)
-  -> boolean
-```
-
-Check if a buffer belongs to the drawer. You can override this function
-to work with other plugins.
-
-#### is_foucsed
-
-```lua
-function DrawerInstance.is_foucsed()
-  -> boolean
-```
-
-Check if the drawer is focused.
-
-#### open
-
-```lua
-function DrawerInstance.open(opts?: DrawerOpenOptions)
-```
-
-Open the drawer.
-
-```lua
-example_drawer.open()
-
---- Keep focus in the drawer.
-example_drawer.open({ focus = true })
-
---- Open a new tab and focus it.
-example_drawer.open({ mode = 'new', focus = true })
-```
-
-#### switch_window_to_buffer
-
-```lua
-function DrawerInstance.switch_window_to_buffer(bufname: string)
-```
-
-Switch the current window to a buffer and prepare it as a drawer.
-
-#### toggle
-
-```lua
-function DrawerInstance.toggle(opts?: DrawerToggleOptions)
-```
-
-Toggle the drawer. Also lets you pass options to open the drawer.
-
-```lua
-example_drawer.toggle()
-
---- Focus the drawer when opening it.
-example_drawer.toggle({ open = { focus = true } })
-```
-
----
-
-### DrawerOpenOptions
-
-#### focus
-
-```lua
-boolean?
-```
-
-#### mode
-
-```lua
-('new'|'previous_or_new')?
-```
-
----
-
-### DrawerState
-
-#### buffers
-
-```lua
-string[]
-```
-
-The names of all buffers that have been created.
-
-#### count
-
-```lua
-integer
-```
-
-The number of buffers that have been created.
-
-#### is_open
-
-```lua
-boolean
-```
-
-Whether the drawer assumes it's open or not.
-
-#### previous_bufname
-
-```lua
-string
-```
-
-The name of the previous buffer that was opened.
-
-#### size
-
-```lua
-integer
-```
-
-The last known size of the drawer.
-
----
-
-### DrawerToggleOptions
-
-#### open
-
-```lua
-DrawerOpenOptions?
-```
-
----
-
-### LuaLS
-
----
-
-### NvimDrawerModule
-
-#### create_drawer
-
-```lua
-function NvimDrawerModule.create_drawer(opts: CreateDrawerOptions)
-  -> DrawerInstance
-```
-
-Create a new drawer.
-
-```lua
-local example_drawer = drawer.create_drawer({
-  bufname_prefix = 'example_drawer_',
-  size = 15,
-  position = 'bottom',
-
-  on_will_create_buffer = function()
-  end,
-})
-```
-
-#### setup
-
-```lua
-function NvimDrawerModule.setup(_: any)
-```
+[API.md](API.md)

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -27,6 +27,9 @@ local mod = {}
 --- Called after the drawer is closed. Only called if the drawer was actually
 --- open.
 --- @field on_did_close? fun(): nil
+--- Called when vim starts up. Helpful to have drawers appear in the order they
+--- were created in.
+--- @field on_vim_enter? fun(instance: DrawerInstance): nil
 
 --- @class DrawerState
 --- Whether the drawer assumes it's open or not.
@@ -464,6 +467,19 @@ function mod.setup(_)
       })
     end
   end, { noremap = true })
+
+  vim.api.nvim_create_autocmd('VimEnter', {
+    desc = 'nvim-drawer: Run on_vim_enter',
+    group = drawer_augroup,
+    once = true,
+    callback = function()
+      for _, instance in ipairs(instances) do
+        if instance.opts.on_vim_enter then
+          instance.opts.on_vim_enter(instance)
+        end
+      end
+    end,
+  })
 
   vim.api.nvim_create_autocmd('TabEnter', {
     desc = 'nvim-drawer: Restore drawers',

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -324,7 +324,6 @@ function mod.create_drawer(opts)
     end
 
     if opts.save_size then
-      vim.print('save_size', instance.get_size())
       instance.state.size = instance.get_size()
     end
 
@@ -507,10 +506,6 @@ function mod.setup(_)
     desc = 'nvim-drawer: Cleanup when buffer is wiped out',
     group = drawer_augroup,
     callback = function(event)
-      vim.print({
-        event = event,
-        winid = vim.fn.bufwinid(event.buf),
-      })
       local bufname = event.file
       for _, instance in ipairs(instances) do
         if instance.is_buffer(bufname) then
@@ -542,7 +537,6 @@ function mod.setup(_)
     desc = 'nvim-drawer: Close tab when all non-drawers are closed',
     group = drawer_augroup,
     callback = function(event)
-      vim.print(event)
       --- @type integer
       --- @diagnostic disable-next-line: assign-type-mismatch
       local closing_window_id = tonumber(event.match)

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -211,7 +211,6 @@ function mod.create_drawer(opts)
           bufnr = bufnr,
         })
       end)
-      -- end
     end
 
     if should_create_buffer then
@@ -251,12 +250,6 @@ function mod.create_drawer(opts)
       table.insert(instance.state.buffers, final_bufnr)
     end
     instance.state.previous_bufnr = final_bufnr
-
-    vim.print('Stored buffer info', {
-      winid = winid,
-      bufnr = final_bufnr,
-      buffers = instance.state.buffers,
-    })
   end
 
   --- Navigate to the next or previous buffer.
@@ -499,7 +492,6 @@ function mod.setup(_)
     desc = 'nvim-drawer: Restore drawers',
     group = drawer_augroup,
     callback = function()
-      vim.print('TabEnter')
       for _, instance in ipairs(instances) do
         if instance.state.is_open then
           -- instance.close({ save_size = false })
@@ -521,7 +513,6 @@ function mod.setup(_)
     desc = 'nvim-drawer: Save drawer sizes',
     group = drawer_augroup,
     callback = function()
-      vim.print('TabLeave')
       for _, instance in ipairs(instances) do
         if instance.state.is_open then
           local size = instance.get_size()

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -87,6 +87,10 @@ end
 --- ```
 --- @param opts CreateDrawerOptions
 function mod.create_drawer(opts)
+  opts = vim.tbl_extend('force', {
+    nvim_tree_hack = false,
+  }, opts or {})
+
   --- @class DrawerInstance
   local instance = {
     --- @type CreateDrawerOptions
@@ -133,14 +137,17 @@ function mod.create_drawer(opts)
       opts or {}
     )
 
-    local bufnr = instance.state.previous_bufnr
-    if opts.mode == 'new' then
-      bufnr = -1
-    end
-
     instance.state.is_open = true
 
     local winid = instance.get_winid()
+
+    local bufnr = instance.state.previous_bufnr
+    if instance.opts.nvim_tree_hack then
+      bufnr = instance.state.windows_and_buffers[winid] or -1
+    end
+    if opts.mode == 'new' then
+      bufnr = -1
+    end
 
     local should_create_buffer = not vim.api.nvim_buf_is_valid(bufnr)
     if should_create_buffer then
@@ -560,7 +567,9 @@ function mod.setup(_)
             return b ~= closing_bufnr
           end, instance.state.buffers)
 
-          instance.state.is_open = false
+          --- TODO While it makes sense to do this here, it results in
+          --- nvim-tree closing when a tab is closed.
+          -- instance.state.is_open = false
           instance.state.previous_bufnr = new_buffers[#new_buffers] or -1
           instance.state.buffers = new_buffers
 

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -152,7 +152,7 @@ function mod.create_drawer(opts)
         bufname = bufname,
       })
 
-      local buffer = vim.api.nvim_create_buf(false, false)
+      local buffer = vim.api.nvim_create_buf(false, true)
       winid = vim.api.nvim_open_win(buffer, false, {
         win = -1,
         split = instance.opts.position,

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,7 @@
+column_width = 80
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferSingle"
+call_parentheses = "Always"
+collapse_simple_statement = "Never"


### PR DESCRIPTION
Some things I want to do:

**Less reliance on buffer names**

nvim-drawer is now mostly about windows, not splits and buffers. `is_buffer` still has to exist to handle `BufWipeout`, since there's no way to get a window id from that event (it's already gone).

My two uses of this are terminals and nvim-tree. Both rename the buffer anyways, so instead of praying the buffer name is predictable, why not let people do what they want and grab the buffer number after all callbacks have fired?

One thing to keep in mind is we can't lose `on_will_create_buffer`. That's called very rarely but is the intended hook for people to use. The rest exist as escape hatches.

**Only track buffer numbers**

To support less reliance on buffer names.