### PR TITLE
feat: Floating window support

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,7 +1,3 @@
-# LuaLS
-
----
-
 # NvimDrawerCloseOptions
 
 ## save_size

--- a/API.md
+++ b/API.md
@@ -1,4 +1,18 @@
-# CreateDrawerOptions
+# LuaLS
+
+---
+
+# NvimDrawerCloseOptions
+
+## save_size
+
+```lua
+boolean?
+```
+
+---
+
+# NvimDrawerCreateOptions
 
 ## nvim_tree_hack
 
@@ -11,7 +25,7 @@ Don't keep the same buffer across all tabs.
 ## on_did_close
 
 ```lua
-fun(event: { instance: DrawerInstance, winid: integer }):nil
+fun(event: { instance: NvimDrawerInstance, winid: integer }):nil
 ```
 
 Called after the drawer is closed. Only called if the drawer was actually
@@ -21,7 +35,7 @@ Not called in the context of the drawer window.
 ## on_did_create_buffer
 
 ```lua
-fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }):nil
+fun(event: { instance: NvimDrawerInstance, winid: integer, bufnr: integer }):nil
 ```
 
 Called after a buffer is created. This is called very rarely.
@@ -30,7 +44,7 @@ Called in the context of the drawer window.
 ## on_did_open
 
 ```lua
-fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }):nil
+fun(event: { instance: NvimDrawerInstance, winid: integer, bufnr: integer }):nil
 ```
 
 Called after .open() is done. Note this will be called even if the drawer
@@ -40,7 +54,7 @@ Called in the context of the drawer window.
 ## on_did_open_buffer
 
 ```lua
-fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }):nil
+fun(event: { instance: NvimDrawerInstance, winid: integer, bufnr: integer }):nil
 ```
 
 Called after a buffer is opened.
@@ -49,7 +63,7 @@ Called in the context of the drawer window.
 ## on_did_open_window
 
 ```lua
-fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }):nil
+fun(event: { instance: NvimDrawerInstance, winid: integer, bufnr: integer }):nil
 ```
 
 Called after a window is created.
@@ -58,7 +72,7 @@ Called in the context of the drawer window.
 ## on_vim_enter
 
 ```lua
-fun(event: { instance: DrawerInstance }):nil
+fun(event: { instance: NvimDrawerInstance }):nil
 ```
 
 Called when vim starts up. Helpful to have drawers appear in the order they
@@ -68,7 +82,7 @@ Not called in the context of the drawer window.
 ## on_will_close
 
 ```lua
-fun(event: { instance: DrawerInstance }):nil
+fun(event: { instance: NvimDrawerInstance }):nil
 ```
 
 Called before the drawer is closed. Note this will is called even if the
@@ -78,7 +92,7 @@ Not called in the context of the drawer window.
 ## on_will_create_buffer
 
 ```lua
-fun(event: { instance: DrawerInstance }):nil
+fun(event: { instance: NvimDrawerInstance }):nil
 ```
 
 Called before a buffer is created. This is called very rarely.
@@ -87,7 +101,7 @@ Not called in the context of the drawer window.
 ## on_will_open_buffer
 
 ```lua
-fun(event: { instance: DrawerInstance }):nil
+fun(event: { instance: NvimDrawerInstance }):nil
 ```
 
 Called before a buffer is opened.
@@ -96,7 +110,7 @@ Not called in the context of the drawer window.
 ## on_will_open_window
 
 ```lua
-fun(event: { instance: DrawerInstance, bufnr: integer }):nil
+fun(event: { instance: NvimDrawerInstance, bufnr: integer }):nil
 ```
 
 Called before the window is created.
@@ -105,7 +119,7 @@ Not called in the context of the drawer window.
 ## position
 
 ```lua
-'above'|'below'|'left'|'right'
+'above'|'below'|'float'|'left'|'right'
 ```
 
 Position of the drawer.
@@ -118,24 +132,29 @@ integer
 
 Initial size of the drawer, in lines or columns.
 
----
-
-# DrawerCloseOptions
-
-## save_size
+## win_config
 
 ```lua
-boolean?
+NvimDrawerWindowConfig?
 ```
+
+Adapted from `vim.api.keyset.win_config`
 
 ---
 
-# DrawerInstance
+# NvimDrawerInstance
+
+## build_win_config
+
+```lua
+function NvimDrawerInstance.build_win_config()
+  -> vim.api.keyset.win_config
+```
 
 ## close
 
 ```lua
-function DrawerInstance.close(opts?: DrawerCloseOptions)
+function NvimDrawerInstance.close(opts?: NvimDrawerCloseOptions)
 ```
 
 Close the drawer. By default, the size of the drawer is saved.
@@ -150,7 +169,7 @@ example_drawer.close({ save_size = false })
 ## does_own_buffer
 
 ```lua
-function DrawerInstance.does_own_buffer(bufnr: any)
+function NvimDrawerInstance.does_own_buffer(bufnr: any)
 ```
 
 Check if a buffer belongs to the drawer.
@@ -158,7 +177,7 @@ Check if a buffer belongs to the drawer.
 ## does_own_window
 
 ```lua
-function DrawerInstance.does_own_window(winid: any)
+function NvimDrawerInstance.does_own_window(winid: any)
   -> boolean
 ```
 
@@ -167,7 +186,7 @@ Check if a window belongs to the drawer.
 ## focus
 
 ```lua
-function DrawerInstance.focus()
+function NvimDrawerInstance.focus()
 ```
 
 Focus the drawer.
@@ -175,7 +194,7 @@ Focus the drawer.
 ## focus_and_return
 
 ```lua
-function DrawerInstance.focus_and_return(callback: fun())
+function NvimDrawerInstance.focus_and_return(callback: fun())
 ```
 
 Helper function to focus the drawer, run a callback, and return focus to
@@ -184,7 +203,7 @@ the previous window.
 ## focus_or_toggle
 
 ```lua
-function DrawerInstance.focus_or_toggle()
+function NvimDrawerInstance.focus_or_toggle()
 ```
 
 Focus the drawer if it's open, otherwise toggle it, and give it focus
@@ -193,7 +212,7 @@ when it is opened.
 ## get_size
 
 ```lua
-function DrawerInstance.get_size()
+function NvimDrawerInstance.get_size()
   -> integer
 ```
 
@@ -202,7 +221,7 @@ Get the size of the drawer in lines or columns.
 ## get_winid
 
 ```lua
-function DrawerInstance.get_winid()
+function NvimDrawerInstance.get_winid()
   -> integer
 ```
 
@@ -212,7 +231,7 @@ open.
 ## go
 
 ```lua
-function DrawerInstance.go(distance: integer)
+function NvimDrawerInstance.go(distance: integer)
 ```
 
 Navigate to the next or previous buffer.
@@ -228,7 +247,7 @@ example_drawer.go(-1)
 ## is_foucsed
 
 ```lua
-function DrawerInstance.is_foucsed()
+function NvimDrawerInstance.is_foucsed()
   -> boolean
 ```
 
@@ -237,7 +256,7 @@ Check if the drawer is focused.
 ## open
 
 ```lua
-function DrawerInstance.open(opts?: DrawerOpenOptions)
+function NvimDrawerInstance.open(opts?: NvimDrawerOpenOptions)
 ```
 
 Open the drawer.
@@ -252,24 +271,16 @@ example_drawer.open({ focus = true })
 example_drawer.open({ mode = 'new', focus = true })
 ```
 
-## set_size
-
-```lua
-function DrawerInstance.set_size(size: integer)
-```
-
-Set the size of the drawer in lines or columns.
-
 ## store_buffer_info
 
 ```lua
-function DrawerInstance.store_buffer_info(winid: integer)
+function NvimDrawerInstance.store_buffer_info(winid: integer)
 ```
 
 ## toggle
 
 ```lua
-function DrawerInstance.toggle(opts?: DrawerToggleOptions)
+function NvimDrawerInstance.toggle(opts?: NvimDrawerToggleOptions)
 ```
 
 Toggle the drawer. Also lets you pass options to open the drawer.
@@ -281,9 +292,44 @@ example_drawer.toggle()
 example_drawer.toggle({ open = { focus = true } })
 ```
 
+## toggle_zoom
+
+```lua
+function NvimDrawerInstance.toggle_zoom()
+```
+
 ---
 
-# DrawerOpenOptions
+# NvimDrawerModule
+
+## create_drawer
+
+```lua
+function NvimDrawerModule.create_drawer(opts: NvimDrawerCreateOptions)
+  -> NvimDrawerInstance
+```
+
+Create a new drawer.
+
+```lua
+local example_drawer = drawer.create_drawer({
+  size = 15,
+  position = 'bottom',
+
+  on_did_create_buffer = function()
+  end,
+})
+```
+
+## setup
+
+```lua
+function NvimDrawerModule.setup(_: any)
+```
+
+---
+
+# NvimDrawerOpenOptions
 
 ## focus
 
@@ -299,7 +345,7 @@ boolean?
 
 ---
 
-# DrawerState
+# NvimDrawerState
 
 ## buffers
 
@@ -333,6 +379,14 @@ boolean
 
 Whether the drawer assumes it's open or not.
 
+## is_zoomed
+
+```lua
+boolean
+```
+
+Whether the drawer is zoomed or not.
+
 ## previous_bufnr
 
 ```lua
@@ -355,49 +409,106 @@ The last known size of the drawer.
 table<integer, integer>
 ```
 
-The windows belonging to the drawer.
-
-- @field winids integer[]
+The windows and buffers belonging to the drawer.
 
 ---
 
-# DrawerToggleOptions
+# NvimDrawerToggleOptions
 
 ## open
 
 ```lua
-DrawerOpenOptions?
+NvimDrawerOpenOptions?
 ```
 
 ---
 
-# LuaLS
+# NvimDrawerWindowConfig
+
+Adapted from `vim.api.keyset.win_config`
+
+## anchor
+
+```lua
+('C'|'CC'|'CE'|'CW'|'E'...(+9))?
+```
+
+## border
+
+```lua
+any
+```
+
+## external
+
+```lua
+boolean?
+```
+
+## fixed
+
+```lua
+boolean?
+```
+
+## focusable
+
+```lua
+boolean?
+```
+
+## footer
+
+```lua
+any
+```
+
+## footer_pos
+
+```lua
+string?
+```
+
+## height
+
+```lua
+number?
+```
+
+## margin
+
+```lua
+number?
+```
+
+## style
+
+```lua
+string?
+```
+
+## title
+
+```lua
+any
+```
+
+## title_pos
+
+```lua
+string?
+```
+
+## width
+
+```lua
+number?
+```
+
+## zindex
+
+```lua
+integer?
+```
 
 ---
-
-# NvimDrawerModule
-
-## create_drawer
-
-```lua
-function NvimDrawerModule.create_drawer(opts: CreateDrawerOptions)
-  -> DrawerInstance
-```
-
-Create a new drawer.
-
-```lua
-local example_drawer = drawer.create_drawer({
-  size = 15,
-  position = 'bottom',
-
-  on_did_create_buffer = function()
-  end,
-})
-```
-
-## setup
-
-```lua
-function NvimDrawerModule.setup(_: any)
-```

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -1,7 +1,7 @@
 --- @class NvimDrawerModule
 local mod = {}
 
---- @class CreateDrawerOptions
+--- @class NvimDrawerCreateOptions
 --- Initial size of the drawer, in lines or columns.
 --- @field size integer
 --- Position of the drawer.
@@ -10,42 +10,42 @@ local mod = {}
 --- @field nvim_tree_hack? boolean
 --- Called before a buffer is created. This is called very rarely.
 --- Not called in the context of the drawer window.
---- @field on_will_create_buffer? fun(event: { instance: DrawerInstance }): nil
+--- @field on_will_create_buffer? fun(event: { instance: NvimDrawerInstance }): nil
 --- Called after a buffer is created. This is called very rarely.
 --- Called in the context of the drawer window.
---- @field on_did_create_buffer? fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }): nil
+--- @field on_did_create_buffer? fun(event: { instance: NvimDrawerInstance, winid: integer, bufnr: integer }): nil
 --- Called before a buffer is opened.
 --- Not called in the context of the drawer window.
---- @field on_will_open_buffer? fun(event: { instance: DrawerInstance }): nil
+--- @field on_will_open_buffer? fun(event: { instance: NvimDrawerInstance }): nil
 --- Called after a buffer is opened.
 --- Called in the context of the drawer window.
---- @field on_did_open_buffer? fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }): nil
+--- @field on_did_open_buffer? fun(event: { instance: NvimDrawerInstance, winid: integer, bufnr: integer }): nil
 --- Called before the window is created.
 --- Not called in the context of the drawer window.
---- @field on_will_open_window? fun(event: { instance: DrawerInstance, bufnr: integer }): nil
+--- @field on_will_open_window? fun(event: { instance: NvimDrawerInstance, bufnr: integer }): nil
 --- Called after a window is created.
 --- Called in the context of the drawer window.
---- @field on_did_open_window? fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }): nil
+--- @field on_did_open_window? fun(event: { instance: NvimDrawerInstance, winid: integer, bufnr: integer }): nil
 --- Called before the drawer is closed. Note this will is called even if the
 --- drawer is closed.
 --- Not called in the context of the drawer window.
---- @field on_will_close? fun(event: { instance: DrawerInstance }): nil
+--- @field on_will_close? fun(event: { instance: NvimDrawerInstance }): nil
 --- Called after the drawer is closed. Only called if the drawer was actually
 --- open.
 --- Not called in the context of the drawer window.
---- @field on_did_close? fun(event: { instance: DrawerInstance, winid: integer }): nil
+--- @field on_did_close? fun(event: { instance: NvimDrawerInstance, winid: integer }): nil
 --- Called when vim starts up. Helpful to have drawers appear in the order they
 --- were created in.
 --- Not called in the context of the drawer window.
---- @field on_vim_enter? fun(event: { instance: DrawerInstance }): nil
+--- @field on_vim_enter? fun(event: { instance: NvimDrawerInstance }): nil
 --- Called after .open() is done. Note this will be called even if the drawer
 --- is open.
 --- Called in the context of the drawer window.
---- @field on_did_open? fun(event: { instance: DrawerInstance, winid: integer, bufnr: integer }): nil
---- @field win_config? DrawerWindowConfig
+--- @field on_did_open? fun(event: { instance: NvimDrawerInstance, winid: integer, bufnr: integer }): nil
+--- @field win_config? NvimDrawerWindowConfig
 
 --- Adapted from `vim.api.keyset.win_config`
---- @class DrawerWindowConfig
+--- @class NvimDrawerWindowConfig
 --- @field margin? number
 --- @field width? number
 --- @field height? number
@@ -61,7 +61,7 @@ local mod = {}
 --- @field style? string
 --- @field fixed? boolean
 
---- @class DrawerState
+--- @class NvimDrawerState
 --- Whether the drawer assumes it's open or not.
 --- @field is_open boolean
 --- The last known size of the drawer.
@@ -79,7 +79,7 @@ local mod = {}
 --- Whether the drawer is zoomed or not.
 --- @field is_zoomed boolean
 
---- @type DrawerInstance[]
+--- @type NvimDrawerInstance[]
 local instances = {}
 
 --- @param t table
@@ -104,18 +104,18 @@ end
 ---   end,
 --- })
 --- ```
---- @param opts CreateDrawerOptions
+--- @param opts NvimDrawerCreateOptions
 function mod.create_drawer(opts)
   opts = vim.tbl_extend('force', {
     nvim_tree_hack = false,
   }, opts or {})
 
-  --- @class DrawerInstance
+  --- @class NvimDrawerInstance
   local instance = {
-    --- @type CreateDrawerOptions
+    --- @type NvimDrawerCreateOptions
     opts = opts,
 
-    --- @type DrawerState
+    --- @type NvimDrawerState
     state = {
       index = #instances + 1,
       is_open = false,
@@ -135,7 +135,7 @@ function mod.create_drawer(opts)
     end
   end
 
-  --- @class DrawerOpenOptions
+  --- @class NvimDrawerOpenOptions
   --- @field focus? boolean
   --- @field mode? 'previous_or_new' | 'new'
 
@@ -149,7 +149,7 @@ function mod.create_drawer(opts)
   --- --- Open a new tab and focus it.
   --- example_drawer.open({ mode = 'new', focus = true })
   --- ```
-  --- @param opts? DrawerOpenOptions
+  --- @param opts? NvimDrawerOpenOptions
   function instance.open(opts)
     opts = vim.tbl_extend(
       'force',
@@ -296,7 +296,7 @@ function mod.create_drawer(opts)
     if instance.opts.position == 'float' then
       win_config.relative = 'editor'
 
-      --- @type DrawerWindowConfig
+      --- @type NvimDrawerWindowConfig
       local instance_win_config = vim.tbl_deep_extend('force', {
         anchor = 'CC',
         margin = 0,
@@ -481,7 +481,7 @@ function mod.create_drawer(opts)
     instance.store_buffer_info(winid)
   end
 
-  --- @class DrawerCloseOptions
+  --- @class NvimDrawerCloseOptions
   --- @field save_size? boolean
 
   --- Close the drawer. By default, the size of the drawer is saved.
@@ -491,7 +491,7 @@ function mod.create_drawer(opts)
   --- --- Don't save the size of the drawer.
   --- example_drawer.close({ save_size = false })
   --- ```
-  --- @param opts? DrawerCloseOptions
+  --- @param opts? NvimDrawerCloseOptions
   function instance.close(opts)
     opts = vim.tbl_extend('force', { save_size = true }, opts or {})
 
@@ -515,8 +515,8 @@ function mod.create_drawer(opts)
     try_callback('on_did_close', { instance = instance, winid = winid })
   end
 
-  --- @class DrawerToggleOptions
-  --- @field open? DrawerOpenOptions
+  --- @class NvimDrawerToggleOptions
+  --- @field open? NvimDrawerOpenOptions
 
   --- Toggle the drawer. Also lets you pass options to open the drawer.
   --- ```lua
@@ -525,7 +525,7 @@ function mod.create_drawer(opts)
   --- --- Focus the drawer when opening it.
   --- example_drawer.toggle({ open = { focus = true } })
   --- ```
-  --- @param opts? DrawerToggleOptions
+  --- @param opts? NvimDrawerToggleOptions
   function instance.toggle(opts)
     opts = vim.tbl_extend('force', { open = nil }, opts or {})
 
@@ -756,7 +756,7 @@ function mod.setup(_)
       --- @diagnostic disable-next-line: assign-type-mismatch
       local closing_window_id = tonumber(event.match)
 
-      --- @type DrawerInstance | nil
+      --- @type NvimDrawerInstance | nil
       local is_closing_drawer = nil
 
       for _, instance in ipairs(instances) do

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -615,26 +615,6 @@ function mod.create_drawer(opts)
     return size
   end
 
-  --- Set the size of the drawer in lines or columns.
-  --- @param size integer
-  function instance.set_size(size)
-    local winid = instance.get_winid()
-    if winid == -1 then
-      return
-    end
-
-    instance.state.size = size
-
-    if
-      instance.opts.position == 'left'
-      or instance.opts.position == 'right'
-    then
-      vim.api.nvim_win_set_width(winid, size)
-    else
-      vim.api.nvim_win_set_height(winid, size)
-    end
-  end
-
   --- Check if a window belongs to the drawer.
   function instance.does_own_window(winid)
     return instance.state.windows_and_buffers[winid] ~= nil

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -232,6 +232,7 @@ function mod.create_drawer(opts)
         winid = winid,
       })
       vim.api.nvim_win_set_buf(winid, bufnr)
+      vim.api.nvim_win_set_config(winid, instance.build_win_config())
       vim.api.nvim_win_call(winid, function()
         try_callback('on_did_open_buffer', {
           instance = instance,
@@ -301,6 +302,7 @@ function mod.create_drawer(opts)
         margin = 0,
       }, instance.opts.win_config or {})
 
+      --- @type vim.api.keyset.win_config
       win_config = vim.tbl_deep_extend('force', win_config, instance_win_config)
 
       local border_width = {
@@ -329,8 +331,16 @@ function mod.create_drawer(opts)
         - (instance_win_config.margin * 2)
       local window_height_int = math.floor(window_height)
         - (instance_win_config.margin * 2)
-      local center_x = (screen_width - window_width) / 2
-      local center_y = ((screen_height - window_height) / 2) - cmdheight
+      local center_x = (
+        screen_width
+        - (window_width_int + border_width.left + border_width.right)
+      ) / 2
+      local center_y = (
+        (
+          screen_height
+          - (window_height_int + border_width.top + border_width.bottom)
+        ) / 2
+      ) - cmdheight
 
       win_config.width = window_width_int
       win_config.height = window_height_int
@@ -677,12 +687,6 @@ function mod.setup(_)
       for _, instance in ipairs(instances) do
         if instance.state.is_open then
           instance.open({ focus = false })
-
-          local winid = instance.get_winid()
-          instance.set_size(instance.state.size)
-
-          local bufnr = instance.state.previous_bufnr
-          vim.api.nvim_win_set_buf(winid, bufnr)
         else
           instance.close({ save_size = false })
         end

--- a/script/build-api-docs
+++ b/script/build-api-docs
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+
+~/.local/share/nvim/mason/bin/lua-language-server --doc lua
+
+GENERATED_LOG_PATH="$HOME/.local/share/nvim/mason/packages/lua-language-server/libexec/log/doc.md"
+END_MARKER="^# _G"
+
+END_LINE=$(grep -n "$END_MARKER" "$GENERATED_LOG_PATH" | cut -d: -f1)
+END_LINE=$((END_LINE - 1))
+
+head -n "$END_LINE" "$GENERATED_LOG_PATH" > API.md

--- a/script/build-api-docs
+++ b/script/build-api-docs
@@ -9,4 +9,5 @@ END_MARKER="^# _G"
 END_LINE=$(grep -n "$END_MARKER" "$GENERATED_LOG_PATH" | cut -d: -f1)
 END_LINE=$((END_LINE - 1))
 
-head -n "$END_LINE" "$GENERATED_LOG_PATH" > API.md
+head -n "$END_LINE" "$GENERATED_LOG_PATH" | tail -n +5 > API.md
+~/.local/share/nvim/mason/packages/prettier/node_modules/prettier/bin/prettier.cjs --write API.md


### PR DESCRIPTION
Since there's no easy way to resize floating windows with a mouse, I've also added a `toggle_zoom()` function. This also works on splits.

## Preview


https://github.com/user-attachments/assets/fa3a5ad8-7355-4d8d-835a-9a06fa76d0e7

