### PR TITLE
feat: Claim existing windows

### DIFF
--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -668,6 +668,28 @@ function mod.create_drawer(opts)
     return vim.list_contains(instance.state.buffers, bufnr)
   end
 
+  --- @param winid integer
+  function instance.claim(winid)
+    if not vim.api.nvim_win_is_valid(winid) then
+      return
+    end
+
+    -- Handle the only current buffer, since the window might detach.
+    local non_floating_windows = vim.tbl_filter(function(tab_winid)
+      return vim.api.nvim_win_get_config(tab_winid).anchor == nil
+    end, vim.api.nvim_tabpage_list_wins(0))
+    if #non_floating_windows == 1 then
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_open_win(buf, false, {
+        win = -1,
+        split = 'above',
+      })
+    end
+
+    instance.store_buffer_info(winid)
+    instance.open({ mode = 'previous_or_new' })
+  end
+
   table.insert(instances, instance)
 
   return instance

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -680,6 +680,12 @@ function mod.create_drawer(opts)
 
     -- Handle the only current buffer, since the window might detach.
     local non_floating_windows = vim.tbl_filter(function(tab_winid)
+      for _, instance in ipairs(instances) do
+        if instance.state.windows_and_buffers[tab_winid] ~= nil then
+          return false
+        end
+      end
+
       return vim.api.nvim_win_get_config(tab_winid).anchor == nil
     end, vim.api.nvim_tabpage_list_wins(0))
     if #non_floating_windows == 1 then
@@ -820,8 +826,6 @@ function mod.setup(_)
     group = drawer_augroup,
     callback = function(event)
       vim.schedule(function()
-        vim.print(event)
-
         --- @type integer
         local bufnr = event.buf
         local winid = vim.fn.bufwinid(bufnr)

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -216,23 +216,7 @@ function mod.create_drawer(opts)
       })
 
       winid = vim.api.nvim_open_win(bufnr, false, instance.build_win_config())
-
-      vim.api.nvim_win_call(winid, function()
-        vim.opt_local.bufhidden = 'hide'
-        vim.opt_local.buflisted = false
-
-        vim.opt_local.equalalways = false
-        if
-          instance.opts.position == 'left'
-          or instance.opts.position == 'right'
-        then
-          vim.opt_local.winfixwidth = true
-          vim.opt_local.winfixheight = false
-        else
-          vim.opt_local.winfixwidth = false
-          vim.opt_local.winfixheight = true
-        end
-      end)
+      instance.initialize_window(winid)
 
       vim.api.nvim_win_call(winid, function()
         try_callback('on_did_open_window', {
@@ -304,6 +288,26 @@ function mod.create_drawer(opts)
       table.insert(instance.state.buffers, final_bufnr)
     end
     instance.state.previous_bufnr = final_bufnr
+  end
+
+  --- @param winid integer
+  function instance.initialize_window(winid)
+    vim.api.nvim_win_call(winid, function()
+      vim.opt_local.bufhidden = 'hide'
+      vim.opt_local.buflisted = false
+
+      vim.opt_local.equalalways = false
+      if
+        instance.opts.position == 'left'
+        or instance.opts.position == 'right'
+      then
+        vim.opt_local.winfixwidth = true
+        vim.opt_local.winfixheight = false
+      else
+        vim.opt_local.winfixwidth = false
+        vim.opt_local.winfixheight = true
+      end
+    end)
   end
 
   --- Builds a win_config for the drawer to be used with `nvim_win_set_config`.
@@ -687,6 +691,7 @@ function mod.create_drawer(opts)
     end
 
     instance.store_buffer_info(winid)
+    instance.initialize_window(winid)
     instance.open({ mode = 'previous_or_new' })
   end
 

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -680,8 +680,8 @@ function mod.create_drawer(opts)
 
     -- Handle the only current buffer, since the window might detach.
     local non_floating_windows = vim.tbl_filter(function(tab_winid)
-      for _, instance in ipairs(instances) do
-        if instance.state.windows_and_buffers[tab_winid] ~= nil then
+      for _, drawer_instance in ipairs(instances) do
+        if drawer_instance.state.windows_and_buffers[tab_winid] ~= nil then
           return false
         end
       end

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -811,6 +811,29 @@ function mod.setup(_)
     end,
   })
 
+  vim.api.nvim_create_autocmd('BufWinEnter', {
+    group = drawer_augroup,
+    callback = function(event)
+      vim.schedule(function()
+        vim.print(event)
+
+        --- @type integer
+        local bufnr = event.buf
+        local winid = vim.fn.bufwinid(bufnr)
+
+        for _, instance in ipairs(instances) do
+          if instance.does_own_window(winid) then
+            if instance.state.windows_and_buffers[winid] == nil then
+              instance.claim(winid)
+            end
+
+            break
+          end
+        end
+      end)
+    end,
+  })
+
   vim.api.nvim_create_autocmd('WinClosed', {
     desc = 'nvim-drawer: Close tab when all non-drawers are closed',
     group = drawer_augroup,


### PR DESCRIPTION
I went with putting this on drawer instances instead of the module itself for now, it lets me lump other things into a "junk" drawer.

This also adds the ability to automatically claim windows, something inspired by edgy.nvim. Now something like this automatically catches `:terminal` and opens it in your dedicated terminal drawer, and integrates it into the tab system:

```lua
drawer.create_drawer({
  size = 15,
  position = 'float',

  win_config = {
    anchor = 'SC',
    margin = 2,
    border = 'rounded',
    width = '100%',
    height = 15,
  },

  does_own_buffer = function(context)
    return context.bufname:match('term://') ~= nil
  end,
})
```

Closes #11 

## Preview


https://github.com/user-attachments/assets/6ceac447-a03d-42d7-9434-7d4f10a2a2d9

