### PR TITLE
chore: Spectre example

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,43 @@ drawer.create_drawer({
 })
 ```
 
+### nvim-spectre
+
+```lua
+local drawer = require('nvim-drawer')
+
+drawer.create_drawer({
+  position = 'below',
+  size = 30,
+
+  does_own_window = function(context)
+    return context.bufname:match('spectre') ~= nil
+  end,
+
+  on_vim_enter = function(event)
+    vim.keymap.set('n', '<leader>S', function()
+      -- If the drawer has never been opened, call spectre. Once its
+      -- window opens, it will be claimed by the drawer, and we can use
+      -- the drawer API afterwards.
+      if
+        #vim.tbl_keys(event.instance.state.windows_and_buffers) == 0
+      then
+        require('spectre').toggle()
+      else
+        event.instance.focus_or_toggle()
+      end
+    end)
+  end,
+
+  -- Remove some UI elements.
+  on_did_open_buffer = function()
+    vim.opt_local.number = false
+    vim.opt_local.signcolumn = 'no'
+    vim.opt_local.statuscolumn = ''
+  end,
+})
+```
+
 ### `NOTES.md` / `.plan`
 
 https://github.com/user-attachments/assets/99161d29-6c41-4209-947e-d20dcea8dd89

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ local drawer = require('nvim-drawer')
 drawer.create_drawer({
   size = 40,
   position = 'right',
-  nvim_tree_hack = true,
+  should_reuse_previous_bufnr = false,
 
   on_vim_enter = function(event)
     --- Open the drawer on startup.

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -134,7 +134,7 @@ end
 --- @param opts NvimDrawerCreateOptions
 function mod.create_drawer(opts)
   opts = vim.tbl_extend('force', {
-    nvim_tree_hack = false,
+    should_reuse_previous_bufnr = true,
   }, opts or {})
 
   --- @class NvimDrawerInstance
@@ -193,9 +193,9 @@ function mod.create_drawer(opts)
 
     -- ... or we use the buffer of the window if it exists ...
     if instance.opts.nvim_tree_hack then
-      instance.opts.should_reuse_previous_bufnr = true
+      instance.opts.should_reuse_previous_bufnr = false
     end
-    if instance.opts.should_reuse_previous_bufnr then
+    if not instance.opts.should_reuse_previous_bufnr then
       bufnr = instance.state.windows_and_buffers[winid] or -1
     end
 
@@ -743,6 +743,7 @@ function mod.create_drawer(opts)
 
       return vim.api.nvim_win_get_config(tab_winid).anchor == nil
     end, vim.api.nvim_tabpage_list_wins(0))
+
     if #non_floating_windows == 1 then
       local buf = vim.api.nvim_create_buf(false, true)
       vim.api.nvim_open_win(buf, false, {


### PR DESCRIPTION
Since I was touching up the README I ended up testing `should_reuse_previous_bufnr` for the nvim-tree example and realized I accidentally flipped the logic there.

Refs #21 
Closes #20 