### PR TITLE
feat: Add 'reasons' for why does_own_* is being called

### DIFF
--- a/API.md
+++ b/API.md
@@ -13,13 +13,13 @@ boolean?
 ## does_own_buffer
 
 ```lua
-(fun(context: { instance: NvimDrawerInstance, bufnr: integer, bufname: string }):boolean)?
+fun(context: { instance: NvimDrawerInstance, bufnr: integer, bufname: string, reason: 'lookup'|'vim_BufWinEnter'|'vim_BufWipeout' }):boolean??
 ```
 
 ## does_own_window
 
 ```lua
-(fun(context: { instance: NvimDrawerInstance, winid: integer, bufnr: integer, bufname: string }):boolean)?
+fun(context: { instance: NvimDrawerInstance, winid: integer, bufnr: integer, bufname: string, reason: 'lookup'|'vim_BufWinEnter' }):boolean??
 ```
 
 ## nvim_tree_hack
@@ -164,6 +164,14 @@ Configuration for the floating window.
 
 ---
 
+# NvimDrawerDoesOwnBufferReason
+
+---
+
+# NvimDrawerDoesOwnWindowReason
+
+---
+
 # NvimDrawerInstance
 
 ## build_win_config
@@ -199,20 +207,33 @@ example_drawer.close({ save_size = false })
 ## does_own_buffer
 
 ```lua
-function NvimDrawerInstance.does_own_buffer(bufnr: integer)
+function NvimDrawerInstance.does_own_buffer(bufnr: integer, reason: 'lookup'|'vim_BufWinEnter'|'vim_BufWipeout')
   -> boolean
 ```
 
 Check if a buffer belongs to the drawer.
 
+```lua
+reason:
+    | 'vim_BufWipeout'
+    | 'lookup'
+    | 'vim_BufWinEnter'
+```
+
 ## does_own_window
 
 ```lua
-function NvimDrawerInstance.does_own_window(winid: integer)
+function NvimDrawerInstance.does_own_window(winid: integer, reason: 'lookup'|'vim_BufWinEnter')
   -> boolean
 ```
 
 Check if a window belongs to the drawer.
+
+```lua
+reason:
+    | 'lookup'
+    | 'vim_BufWinEnter'
+```
 
 ## focus
 

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -711,10 +711,6 @@ function mod.create_drawer(opts)
       return false
     end
 
-    if instance.state.windows_and_buffers[winid] ~= nil then
-      return true
-    end
-
     local bufnr = vim.api.nvim_win_get_buf(winid)
     if instance.opts.does_own_window then
       local user_response = instance.opts.does_own_window({
@@ -730,6 +726,10 @@ function mod.create_drawer(opts)
       end
     end
 
+    if instance.state.windows_and_buffers[winid] ~= nil then
+      return true
+    end
+
     return instance.does_own_buffer(bufnr, reason)
   end
 
@@ -739,16 +739,6 @@ function mod.create_drawer(opts)
   function instance.does_own_buffer(bufnr, reason)
     if not vim.api.nvim_buf_is_valid(bufnr) then
       return false
-    end
-
-    if vim.list_contains(instance.state.buffers, bufnr) then
-      return true
-    end
-
-    for _, buf in pairs(instance.state.windows_and_buffers) do
-      if buf == bufnr then
-        return true
-      end
     end
 
     if instance.opts.does_own_buffer then
@@ -761,6 +751,16 @@ function mod.create_drawer(opts)
 
       if user_response ~= nil then
         return user_response
+      end
+    end
+
+    if vim.list_contains(instance.state.buffers, bufnr) then
+      return true
+    end
+
+    for _, buf in pairs(instance.state.windows_and_buffers) do
+      if buf == bufnr then
+        return true
       end
     end
 

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -2,7 +2,7 @@
 local mod = {}
 
 --- @alias NvimDrawerDoesOwnWindowReason 'lookup' | 'vim_BufWinEnter'
---- @alias NvimDrawerDoesOwnBufferReason 'window_lookup' | 'vim_BufWipeout'
+--- @alias NvimDrawerDoesOwnBufferReason 'vim_BufWipeout' | NvimDrawerDoesOwnWindowReason
 
 --- @class NvimDrawerCreateOptions
 --- Initial size of the drawer, in lines or columns.
@@ -730,7 +730,7 @@ function mod.create_drawer(opts)
       end
     end
 
-    return instance.does_own_buffer(bufnr, 'window_lookup')
+    return instance.does_own_buffer(bufnr, reason)
   end
 
   --- Check if a buffer belongs to the drawer.

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -595,7 +595,6 @@ function mod.create_drawer(opts)
 
     instance.store_buffer_info(winid)
     vim.api.nvim_win_close(winid, false)
-    -- instance.state.windows_and_buffers[winid] = nil
     try_callback('on_did_close', { instance = instance, winid = winid })
   end
 
@@ -856,16 +855,15 @@ function mod.setup(options)
     callback = function()
       -- Without `vim.schedule`, when calling `nvim_buf_get_name` with the
       -- buffer in the new tab, the name of the previous buffer is returned not
-      -- an empty string
-      -- as expected.
+      -- an empty string as expected.
       vim.schedule(function()
         for _, instance in ipairs(get_sorted_instances()) do
           if instance.state.is_open then
             instance.open({ focus = false })
           else
             -- Close here can cause issues with the automatic claiming, IE if a
-            -- drawer owns `NOTES.md`, then the user does `:tabedit NOTES.md`,
-            -- the new tab is closed immediately.
+            -- drawer tries to claim `NOTES.md` and the user does `:tabedit
+            -- NOTES.md`, the new tab is closed immediately.
             -- This works around that.
             if not is_entering_new_tab then
               instance.close({ save_size = false })
@@ -927,22 +925,21 @@ function mod.setup(options)
 
       for _, instance in ipairs(instances) do
         if instance.does_own_buffer(closing_bufnr, 'vim_BufWipeout') then
-          local new_buffers = vim.tbl_filter(function(b)
-            return b ~= closing_bufnr
-          end, instance.state.buffers)
-
           --- TODO While it makes sense to do this here, it results in
           --- nvim-tree closing when a tab is closed.
           -- instance.state.is_open = false
-          instance.state.previous_bufnr = new_buffers[#new_buffers] or -1
-          instance.state.buffers = new_buffers
 
+          instance.state.buffers = vim.tbl_filter(function(b)
+            return b ~= closing_bufnr
+          end, instance.state.buffers)
           for winid, bufnr in pairs(instance.state.windows_and_buffers) do
             if bufnr == closing_bufnr then
               instance.state.windows_and_buffers[winid] = nil
             end
           end
 
+          instance.state.previous_bufnr = instance.state.buffers[#instance.state.buffers]
+            or -1
           if instance.state.previous_bufnr ~= -1 and instance.state.is_open then
             instance.open({ focus = false })
           end


### PR DESCRIPTION
The idea behind this is so users / developers can say "no, I don't own this window in this context".

The rest of the code isn't really set up for this. Like, if you want to say "when `BufWipeout` is closed, I don't want to say I own this window", that's not possible because that check is called _after_ some internal checks happen. To support this, some small orders of operations will need to change.