### PR TITLE
feat: Bufwipeout changes

### DIFF
--- a/API.md
+++ b/API.md
@@ -138,6 +138,12 @@ Position of the drawer.
 boolean?
 ```
 
+## should_close_on_bufwipeout
+
+```lua
+boolean?
+```
+
 ## should_reuse_previous_bufnr
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ drawer.create_drawer({
   size = 40,
   position = 'right',
   should_reuse_previous_bufnr = false,
+  should_close_on_bufwipeout = false,
 
   on_vim_enter = function(event)
     --- Open the drawer on startup.

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -915,18 +915,26 @@ function mod.setup(options)
 
       for _, instance in ipairs(instances) do
         if instance.does_own_buffer(closing_bufnr) then
+          --- Remove the buffer from the instance.
           instance.state.buffers = vim.tbl_filter(function(b)
             return b ~= closing_bufnr
           end, instance.state.buffers)
+
+          --- Remove any windows that were using the buffer.
           for winid, bufnr in pairs(instance.state.windows_and_buffers) do
             if bufnr == closing_bufnr then
               instance.state.windows_and_buffers[winid] = nil
             end
           end
 
+          --- Make sure previous_bufnr isn't set to an invalid buffer.
           instance.state.previous_bufnr = instance.state.buffers[#instance.state.buffers]
             or -1
+
+          --- If there is an alternative buffer ...
           if instance.state.previous_bufnr ~= -1 then
+            --- ... and the drawer was open AND has should_reuse_previous_bufnr
+            --- enabled, then call open. That makes the previous buffer appear.
             if
               instance.state.is_open
               and instance.opts.should_reuse_previous_bufnr
@@ -934,6 +942,7 @@ function mod.setup(options)
               instance.open({ mode = 'previous_or_new', focus = false })
             end
           else
+            --- Otherwise, close the drawer.
             if instance.opts.should_close_on_bufwipeout then
               instance.state.is_open = false
             end

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -592,7 +592,6 @@ function mod.create_drawer(opts)
 
     instance.store_buffer_info(winid)
     vim.api.nvim_win_close(winid, false)
-    -- instance.state.windows_and_buffers[winid] = nil
     try_callback('on_did_close', { instance = instance, winid = winid })
   end
 
@@ -845,16 +844,15 @@ function mod.setup(options)
     callback = function()
       -- Without `vim.schedule`, when calling `nvim_buf_get_name` with the
       -- buffer in the new tab, the name of the previous buffer is returned not
-      -- an empty string
-      -- as expected.
+      -- an empty string as expected.
       vim.schedule(function()
         for _, instance in ipairs(get_sorted_instances()) do
           if instance.state.is_open then
             instance.open({ focus = false })
           else
             -- Close here can cause issues with the automatic claiming, IE if a
-            -- drawer owns `NOTES.md`, then the user does `:tabedit NOTES.md`,
-            -- the new tab is closed immediately.
+            -- drawer tries to claim `NOTES.md` and the user does `:tabedit
+            -- NOTES.md`, the new tab is closed immediately.
             -- This works around that.
             if not is_entering_new_tab then
               instance.close({ save_size = false })
@@ -915,22 +913,21 @@ function mod.setup(options)
 
       for _, instance in ipairs(instances) do
         if instance.does_own_buffer(closing_bufnr) then
-          local new_buffers = vim.tbl_filter(function(b)
-            return b ~= closing_bufnr
-          end, instance.state.buffers)
-
           --- TODO While it makes sense to do this here, it results in
           --- nvim-tree closing when a tab is closed.
           -- instance.state.is_open = false
-          instance.state.previous_bufnr = new_buffers[#new_buffers] or -1
-          instance.state.buffers = new_buffers
 
+          instance.state.buffers = vim.tbl_filter(function(b)
+            return b ~= closing_bufnr
+          end, instance.state.buffers)
           for winid, bufnr in pairs(instance.state.windows_and_buffers) do
             if bufnr == closing_bufnr then
               instance.state.windows_and_buffers[winid] = nil
             end
           end
 
+          instance.state.previous_bufnr = instance.state.buffers[#instance.state.buffers]
+            or -1
           if instance.state.previous_bufnr ~= -1 and instance.state.is_open then
             instance.open({ focus = false })
           end


### PR DESCRIPTION
The tricky part with this was that both of these should be true:

If the user exits a terminal with `^D` or `exit`, then the drawer should close _and stay closed_ when going to a new tab. In this case the user is saying "go away drawer".

If the user has a drawer with nvim-tree open and closes the tab, the drawer should remain open (they didn't manually close the drawer, `BufWipeout` happening on tabclose is a nvim-drawer thing, not a vim thing).