### PR TITLE
fix: set `nested` on `WinClosed` event so `qall` propagates

### DIFF
--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -988,6 +988,7 @@ function mod.setup(options)
   vim.api.nvim_create_autocmd('WinClosed', {
     desc = 'nvim-drawer: Close tab when all non-drawers are closed',
     group = drawer_augroup,
+    nested = true,
     callback = function(event)
       --- @type integer
       --- @diagnostic disable-next-line: assign-type-mismatch

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -91,7 +91,7 @@ local current_options = default_options
 --- @type NvimDrawerInstance[]
 local instances = {}
 
-function get_sorted_instances()
+local function get_sorted_instances()
   --- @type NvimDrawerInstance[]
   local sorted_instances = {}
 


### PR DESCRIPTION
I noticed that `VimLeavePre` wasn't firing all the time and found the culprit here