### PR TITLE
feat: Call `on_vim_enter` manually if `VimEnter` was missed

### DIFF
--- a/API.md
+++ b/API.md
@@ -190,7 +190,7 @@ function NvimDrawerInstance.claim(winid: integer)
 ## close
 
 ```lua
-function NvimDrawerInstance.close(opts?: NvimDrawerCloseOptions)
+function NvimDrawerInstance.close(close_opts?: NvimDrawerCloseOptions)
 ```
 
 Close the drawer. By default, the size of the drawer is saved.
@@ -299,7 +299,7 @@ Check if the drawer is focused.
 ## open
 
 ```lua
-function NvimDrawerInstance.open(opts?: NvimDrawerOpenOptions)
+function NvimDrawerInstance.open(open_opts?: NvimDrawerOpenOptions)
 ```
 
 Open the drawer.
@@ -325,7 +325,7 @@ Store the current window and buffer information.
 ## toggle
 
 ```lua
-function NvimDrawerInstance.toggle(opts?: NvimDrawerToggleOptions)
+function NvimDrawerInstance.toggle(toggle_opts?: NvimDrawerToggleOptions)
 ```
 
 Toggle the drawer. Also lets you pass options to open the drawer.
@@ -480,6 +480,8 @@ NvimDrawerOpenOptions?
 ---
 
 # NvimDrawerWindowConfig
+
+Extends `vim.api.keyset.win_config`
 
 ## anchor
 

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -840,18 +840,20 @@ function mod.setup(options)
   --   end
   -- end, { noremap = true })
 
-  vim.api.nvim_create_autocmd('VimEnter', {
-    desc = 'nvim-drawer: Run on_vim_enter',
-    group = drawer_augroup,
-    once = true,
-    callback = function()
-      for _, instance in ipairs(instances) do
-        if instance.opts.on_vim_enter then
-          instance.opts.on_vim_enter({ instance = instance })
+  if not vim.v.vim_did_enter then
+    vim.api.nvim_create_autocmd('VimEnter', {
+      desc = 'nvim-drawer: Run on_vim_enter',
+      group = drawer_augroup,
+      once = true,
+      callback = function()
+        for _, instance in ipairs(instances) do
+          if instance.opts.on_vim_enter then
+            instance.opts.on_vim_enter({ instance = instance })
+          end
         end
-      end
-    end,
-  })
+      end,
+    })
+  end
 
   vim.api.nvim_create_autocmd('TabEnter', {
     desc = 'nvim-drawer: Restore drawers',

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -153,6 +153,7 @@ end
 --- ```
 --- @param opts NvimDrawerCreateOptions
 function mod.create_drawer(opts)
+  --- @type NvimDrawerCreateOptions
   opts = vim.tbl_extend('force', {
     should_reuse_previous_bufnr = true,
     should_claim_new_window = true,
@@ -199,6 +200,7 @@ function mod.create_drawer(opts)
   --- ```
   --- @param open_opts? NvimDrawerOpenOptions
   function instance.open(open_opts)
+    --- @type NvimDrawerOpenOptions
     open_opts = vim.tbl_extend(
       'force',
       { focus = false, mode = 'previous_or_new' },
@@ -222,7 +224,7 @@ function mod.create_drawer(opts)
 
     -- ... and finally if we are trying to make a new window, we just force it
     -- to -1 so a buffer will be created.
-    if opts.mode == 'new' then
+    if open_opts.mode == 'new' then
       bufnr = -1
     end
 
@@ -293,7 +295,7 @@ function mod.create_drawer(opts)
       end)
     end
 
-    if opts.focus then
+    if open_opts.focus then
       vim.api.nvim_set_current_win(winid)
     end
 
@@ -579,6 +581,7 @@ function mod.create_drawer(opts)
   --- ```
   --- @param close_opts? NvimDrawerCloseOptions
   function instance.close(close_opts)
+    --- @type NvimDrawerCloseOptions
     close_opts = vim.tbl_extend('force', { save_size = true }, close_opts or {})
 
     try_callback('on_will_close', { instance = instance })
@@ -612,6 +615,7 @@ function mod.create_drawer(opts)
   --- ```
   --- @param toggle_opts? NvimDrawerToggleOptions
   function instance.toggle(toggle_opts)
+    --- @type NvimDrawerToggleOptions
     toggle_opts = vim.tbl_extend('force', { open = nil }, toggle_opts or {})
 
     if instance.state.is_open then

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -88,8 +88,6 @@ local default_options = {
 
 local current_options = default_options
 
-local did_vim_enter_already = false
-
 --- @type NvimDrawerInstance[]
 local instances = {}
 
@@ -794,7 +792,7 @@ function mod.create_drawer(opts)
 
   table.insert(instances, instance)
 
-  if did_vim_enter_already then
+  if vim.v.vim_did_enter then
     if instance.opts.on_vim_enter then
       instance.opts.on_vim_enter({ instance = instance })
     end
@@ -848,8 +846,6 @@ function mod.setup(options)
           instance.opts.on_vim_enter({ instance = instance })
         end
       end
-
-      did_vim_enter_already = true
     end,
   })
 

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -88,6 +88,8 @@ local default_options = {
 
 local current_options = default_options
 
+local did_vim_enter_already = false
+
 --- @type NvimDrawerInstance[]
 local instances = {}
 
@@ -789,6 +791,12 @@ function mod.create_drawer(opts)
 
   table.insert(instances, instance)
 
+  if did_vim_enter_already then
+    if instance.opts.on_vim_enter then
+      instance.opts.on_vim_enter({ instance = instance })
+    end
+  end
+
   return instance
 end
 
@@ -837,6 +845,8 @@ function mod.setup(options)
           instance.opts.on_vim_enter({ instance = instance })
         end
       end
+
+      did_vim_enter_already = true
     end,
   })
 

--- a/lua/nvim-drawer/init.lua
+++ b/lua/nvim-drawer/init.lua
@@ -199,12 +199,12 @@ function mod.create_drawer(opts)
   --- --- Open a new tab and focus it.
   --- example_drawer.open({ mode = 'new', focus = true })
   --- ```
-  --- @param opts? NvimDrawerOpenOptions
-  function instance.open(opts)
-    opts = vim.tbl_extend(
+  --- @param open_opts? NvimDrawerOpenOptions
+  function instance.open(open_opts)
+    open_opts = vim.tbl_extend(
       'force',
       { focus = false, mode = 'previous_or_new' },
-      opts or {}
+      open_opts or {}
     )
 
     instance.state.is_open = true
@@ -309,10 +309,13 @@ function mod.create_drawer(opts)
 
     instance.store_buffer_info(winid)
 
-    for _, instance in ipairs(get_sorted_instances()) do
-      local drawer_winid = instance.get_winid()
+    for _, drawer_instance in ipairs(get_sorted_instances()) do
+      local drawer_winid = drawer_instance.get_winid()
       if drawer_winid ~= -1 then
-        vim.api.nvim_win_set_config(drawer_winid, instance.build_win_config())
+        vim.api.nvim_win_set_config(
+          drawer_winid,
+          drawer_instance.build_win_config()
+        )
       end
     end
   end
@@ -576,9 +579,9 @@ function mod.create_drawer(opts)
   --- --- Don't save the size of the drawer.
   --- example_drawer.close({ save_size = false })
   --- ```
-  --- @param opts? NvimDrawerCloseOptions
-  function instance.close(opts)
-    opts = vim.tbl_extend('force', { save_size = true }, opts or {})
+  --- @param close_opts? NvimDrawerCloseOptions
+  function instance.close(close_opts)
+    close_opts = vim.tbl_extend('force', { save_size = true }, close_opts or {})
 
     try_callback('on_will_close', { instance = instance })
 
@@ -590,7 +593,7 @@ function mod.create_drawer(opts)
       return
     end
 
-    if opts.save_size then
+    if close_opts.save_size then
       instance.state.size = instance.get_size()
     end
 
@@ -609,14 +612,14 @@ function mod.create_drawer(opts)
   --- --- Focus the drawer when opening it.
   --- example_drawer.toggle({ open = { focus = true } })
   --- ```
-  --- @param opts? NvimDrawerToggleOptions
-  function instance.toggle(opts)
-    opts = vim.tbl_extend('force', { open = nil }, opts or {})
+  --- @param toggle_opts? NvimDrawerToggleOptions
+  function instance.toggle(toggle_opts)
+    toggle_opts = vim.tbl_extend('force', { open = nil }, toggle_opts or {})
 
     if instance.state.is_open then
       instance.close({ save_size = true })
     else
-      instance.open(opts.open)
+      instance.open(toggle_opts.open)
     end
   end
 


### PR DESCRIPTION
Been working on migrating my neovim setup to `vim.pack` and not sure if it's because I've been putting my `vim.pack.add`'s in `plugin/` my use of `vim.schedule`, or some combination of them. Either way, there's a chance `.setup` is called after `VimEnter` has happened, in which case the `on_vim_enter` callback is never called.

So if that's the case we can just call those functions immediately.